### PR TITLE
Issue 43 Addedit Save Button

### DIFF
--- a/app/src/main/res/layout/activity_aisle_add.xml
+++ b/app/src/main/res/layout/activity_aisle_add.xml
@@ -27,6 +27,11 @@
             android:text="@string/standarddonebutton"
             android:visibility="invisible"
             android:onClick="doneAdding"/>
+        <Button
+            android:id="@+id/aisleaddedit_save_button"
+            style="@style/textviewbutton"
+            android:text="@string/shopsavebutton"
+            android:onClick="saveClicked" />
     </LinearLayout>
     <LinearLayout
         android:id="@+id/aisleaddedit_help_layout"
@@ -142,18 +147,6 @@
             android:layout_width="@dimen/standard_dummy_size"
             android:layout_height="match_parent"
             android:layout_weight="0.4"/>
-    </LinearLayout>
-    <LinearLayout
-        android:id="@+id/aisleaddedit_mid_buttons"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/standard_button_height"
-        android:layout_margin="@dimen/standard_dummy_size">
-        <Button
-            android:id="@+id/aisleaddedit_save_button"
-            style="@style/textviewbutton"
-            android:text="@string/shopsavebutton"
-            android:onClick="saveClicked" />
     </LinearLayout>
     <LinearLayout
         android:id="@+id/aisleaddedit_aislelist_header1_layout"


### PR DESCRIPTION
  #43  Moved  button **aisleaddedit_save_button** xml from  LinLayout**aisleaddedit_mid_buttons** to LinLayout **aisleaddedit_top_buttons** and removed LinLayout aisleaddedit_mid_buttons as now redundant.

```
<LinearLayout
- android:id="@+id/aisleaddedit_mid_buttons"
- android:orientation="horizontal"
- android:layout_width="match_parent"
- android:layout_height="@dimen/standard_button_height"
- android:layout_margin="@dimen/standard_dummy_size">
- <Button
- android:id="@+id/aisleaddedit_save_button"
- style="@style/textviewbutton"
- android:text="@string/shopsavebutton"
- android:onClick="saveClicked" />
- </LinearLayout>
```
