### PR TITLE
User guide stuff

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mjt.shopper"
     android:installLocation="auto">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/mjt/shopper/AisleListSpinnerAdapter.java
+++ b/app/src/main/java/mjt/shopper/AisleListSpinnerAdapter.java
@@ -12,6 +12,10 @@ import android.widget.TextView;
  * Created by Mike092015 on 11/02/2016.
  */
 class AisleListSpinnerAdapter extends CursorAdapter {
+    public static int aisleidoffset;
+    public static int aislenameoffset;
+    public static int aisleorderoffset;
+    public static int aisleshoprefoffset;
 
     public AisleListSpinnerAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
@@ -20,15 +24,22 @@ class AisleListSpinnerAdapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        // get column offsets from cursor (once to reduce overheads)
+        if(cursor.getPosition() == 0) {
+            aisleidoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ID);
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            aisleorderoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ORDER);
+            aisleshoprefoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_SHOP);
+        }
         TextView tvaisleid = (TextView) view.findViewById(R.id.aisle_id_entry);
         TextView tvaislename = (TextView) view.findViewById(R.id.aisle_name_entry);
         TextView tvaisleorder = (TextView) view.findViewById(R.id.aisle_order_entry);
         TextView tvaisleshopref = (TextView) view.findViewById(R.id.aisle_shopref_entry);
 
-        tvaisleid.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_ID_INDEX));
-        tvaislename.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_NAME_INDEX));
-        tvaisleorder.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_ORDER_INDEX));
-        tvaisleshopref.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_SHOP_INDEX));
+        tvaisleid.setText(cursor.getString(aisleidoffset));
+        tvaislename.setText(cursor.getString(aislenameoffset));
+        tvaisleorder.setText(cursor.getString(aisleorderoffset));
+        tvaisleshopref.setText(cursor.getString(aisleshoprefoffset));
     }
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
         return LayoutInflater.from(context).inflate(R.layout.activity_aisle_list_entry, parent,false);

--- a/app/src/main/java/mjt/shopper/AislesCursorAdapter.java
+++ b/app/src/main/java/mjt/shopper/AislesCursorAdapter.java
@@ -13,6 +13,11 @@ import android.widget.TextView;
  * Created by Mike092015 on 6/02/2016.
         */
 class AislesCursorAdapter extends CursorAdapter {
+    public static int aisleidoffset;
+    public static int aislenameoffset;
+    public static int aisleorderoffset;
+    public static int aisleshoprefoffset;
+
     public AislesCursorAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -30,15 +35,22 @@ class AislesCursorAdapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        // get column offsets from cursor (once to reduce overheads)
+        if(cursor.getPosition() == 0) {
+            aisleidoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ID);
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            aisleorderoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ORDER);
+            aisleshoprefoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_SHOP);
+        }
         TextView textviewaisleid = (TextView) view.findViewById(R.id.aisle_id_entry);
         TextView textviewaislename = (TextView) view.findViewById(R.id.aisle_name_entry);
         TextView textviewaisleorder = (TextView) view.findViewById(R.id.aisle_order_entry);
         TextView textviewaisleshopref = (TextView) view.findViewById(R.id.aisle_shopref_entry);
 
-        textviewaisleid.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_ID_INDEX));
-        textviewaislename.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_NAME_INDEX));
-        textviewaisleorder.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_ORDER_INDEX));
-        textviewaisleshopref.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_SHOP_INDEX));
+        textviewaisleid.setText(cursor.getString(aisleidoffset));
+        textviewaislename.setText(cursor.getString(aislenameoffset));
+        textviewaisleorder.setText(cursor.getString(aisleorderoffset));
+        textviewaisleshopref.setText(cursor.getString(aisleshoprefoffset));
     }
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {

--- a/app/src/main/java/mjt/shopper/Database_Inspector_AislesDB_Adapter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_AislesDB_Adapter.java
@@ -13,6 +13,11 @@ import android.widget.TextView;
  * Created by Mike092015 on 17/02/2016.
  */
 public class Database_Inspector_AislesDB_Adapter extends CursorAdapter {
+    public static int aisleidoffset;
+    public static int aislenameoffset;
+    public static int aisleorderoffset;
+    public static int aisleshoprefoffset;
+
     public Database_Inspector_AislesDB_Adapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -30,15 +35,23 @@ public class Database_Inspector_AislesDB_Adapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        // get column offsets from cursor (once to reduce overheads)
+        if(cursor.getPosition() == 0) {
+            aisleidoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ID);
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            aisleorderoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ORDER);
+            aisleshoprefoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_SHOP);
+        }
+
         TextView textviewaisleid = (TextView) view.findViewById(R.id.adiae_aislesdb_id);
         TextView textviewaisleshopref = (TextView) view.findViewById(R.id.adiae_aislesdb_shopref);
         TextView textviewaislesorder = (TextView) view.findViewById(R.id.adiae_aislesdb_order);
         TextView textviewaislesaislename = (TextView) view.findViewById(R.id.adiae_aislesdb_aislename);
 
-        textviewaisleid.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_ID_INDEX));
-        textviewaislesaislename.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_NAME_INDEX));
-        textviewaislesorder.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_ORDER_INDEX));
-        textviewaisleshopref.setText(cursor.getString(ShopperDBHelper.AISLES_COLUMN_SHOP_INDEX));
+        textviewaisleid.setText(cursor.getString(aisleidoffset));
+        textviewaislesaislename.setText(cursor.getString(aislenameoffset));
+        textviewaislesorder.setText(cursor.getString(aisleorderoffset));
+        textviewaisleshopref.setText(cursor.getString(aisleshoprefoffset));
     }
     public View newView(Context context, Cursor cursos, ViewGroup parent) {
         return LayoutInflater.from(context).inflate(R.layout.activity_database_inspect_aislesdb_entry, parent, false);

--- a/app/src/main/java/mjt/shopper/Database_Inspector_ProductUsageDB_Adapter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_ProductUsageDB_Adapter.java
@@ -16,6 +16,14 @@ import java.text.NumberFormat;
  * Created by Mike092015 on 17/02/2016.
  */
 public class Database_Inspector_ProductUsageDB_Adapter extends CursorAdapter{
+    public static int productusageaislrefoffset;
+    public static int productusageproductrefoffset;
+    public static int productusagecostoffset;
+    public static int productusagebuycountoffset;
+    public static int productusagefirstbudateoffset;
+    public static int productusagelatestbutdateoffset;
+    public static int productusagemincostoffset;
+
     public Database_Inspector_ProductUsageDB_Adapter(Context context, Cursor cursor, int flags) {
         super(context,cursor, 0);
     }
@@ -34,6 +42,15 @@ public class Database_Inspector_ProductUsageDB_Adapter extends CursorAdapter{
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            productusageaislrefoffset = cursor.getColumnIndex("_id"); // Note set to id via as in SQL
+            productusageproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_PRODUCTREF);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST);
+            productusagebuycountoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_BUYCOUNT);
+            productusagefirstbudateoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_FIRSTBUYDATE);
+            productusagelatestbutdateoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_LATESTBUYDATE);
+            productusagemincostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_MINCOST);
+        }
         TextView textviewproductusageaislref = (TextView) view.findViewById(R.id.adipue_productusagedb_aisleref);
         TextView textviewproductusageproductref = (TextView) view.findViewById(R.id.adipue_productusagedb_productref);
         TextView textviewproductusagecost = (TextView) view.findViewById(R.id.adipue_productusagedb_cost);
@@ -42,13 +59,13 @@ public class Database_Inspector_ProductUsageDB_Adapter extends CursorAdapter{
         TextView textviewproductusagelastbuydate = (TextView) view.findViewById(R.id.adipue_productusagedb_productlastbuydate);
         TextView textviewproductusagemincost = (TextView) view.findViewById(R.id.adipue_productusagedb_mincost);
 
-        textviewproductusageaislref.setText(cursor.getString(ShopperDBHelper.PRODUCTUSAGE_COLUMN_AISLEREF_INDEX));
-        textviewproductusageproductref.setText(cursor.getString(ShopperDBHelper.PRODUCTUSAGE_COLUMN_PRODUCTREF_INDEX));
-        textviewproductusagecost.setText(NumberFormat.getCurrencyInstance().format(cursor.getFloat(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST_INDEX)));
-        textviewproductusagebuycount.setText(cursor.getString(ShopperDBHelper.PRODUCTUSAGE_COLUMN_BUYCOUNT_INDEX));
-        textviewproductusagefirstbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT,cursor.getLong(ShopperDBHelper.PRODUCTUSAGE_COLUMN_FIRSTBUYDATE_INDEX)));
-        textviewproductusagelastbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT, cursor.getLong(ShopperDBHelper.PRODUCTUSAGE_COLUMN_LASTBUYDATE_INDEX)));
-        textviewproductusagemincost.setText(NumberFormat.getCurrencyInstance().format(cursor.getLong(ShopperDBHelper.PRODUCTUSAGE_COLUMN_MINCOST_INDEX)));
+        textviewproductusageaislref.setText(cursor.getString(productusageaislrefoffset));
+        textviewproductusageproductref.setText(cursor.getString(productusageproductrefoffset));
+        textviewproductusagecost.setText(NumberFormat.getCurrencyInstance().format(cursor.getFloat(productusagecostoffset)));
+        textviewproductusagebuycount.setText(cursor.getString(productusagebuycountoffset));
+        textviewproductusagefirstbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT,cursor.getLong(productusagefirstbudateoffset)));
+        textviewproductusagelastbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT, cursor.getLong(productusagelatestbutdateoffset)));
+        textviewproductusagemincost.setText(NumberFormat.getCurrencyInstance().format(cursor.getLong(productusagemincostoffset)));
     }
 
     @Override

--- a/app/src/main/java/mjt/shopper/Database_Inspector_ProductsDB_Adadpter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_ProductsDB_Adadpter.java
@@ -13,6 +13,13 @@ import android.widget.TextView;
  * Created by Mike092015 on 17/02/2016.
  */
 public class Database_Inspector_ProductsDB_Adadpter extends CursorAdapter {
+    public static int productidoffset;
+    public static int productnameoffset;
+    public static int productorderoffset;
+    public static int productaisleoffset;
+    public static int productnotesoffset;
+    public static int productusesoffset;
+
     public Database_Inspector_ProductsDB_Adadpter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -33,6 +40,15 @@ public class Database_Inspector_ProductsDB_Adadpter extends CursorAdapter {
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
 
+        if(cursor.getPosition() == 0) {
+            productidoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ID);
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            productorderoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ORDER);
+            productaisleoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_AISLE);
+            productnotesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NOTES);
+            productusesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_USES);
+        }
+
         TextView textviewproductid = (TextView) view.findViewById(R.id.adipe_productsdb_id);
         TextView textviewproductname = (TextView) view.findViewById(R.id.adipe_productsdb_name);
         TextView textviewproductorder = (TextView) view.findViewById(R.id.adipe_productsdb_order);
@@ -40,12 +56,12 @@ public class Database_Inspector_ProductsDB_Adadpter extends CursorAdapter {
         TextView textviewproductuses = (TextView) view.findViewById(R.id.adipe_productsdb_uses);
         TextView textviewproductnotes = (TextView) view.findViewById(R.id.adipe_productsdb_notes);
 
-        textviewproductid.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ID_INDEX));
-        textviewproductname.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NAME_INDEX));
-        textviewproductorder.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ORDER_INDEX));
-        textviewproductaisle.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_AISLE_INDEX));
-        textviewproductuses.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_USES_INDEX));
-        textviewproductnotes.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NOTES_INDEX));
+        textviewproductid.setText(cursor.getString(productidoffset));
+        textviewproductname.setText(cursor.getString(productnameoffset));
+        textviewproductorder.setText(cursor.getString(productorderoffset));
+        textviewproductaisle.setText(cursor.getString(productaisleoffset));
+        textviewproductuses.setText(cursor.getString(productusesoffset));
+        textviewproductnotes.setText(cursor.getString(productnotesoffset));
 
     }
     @Override

--- a/app/src/main/java/mjt/shopper/Database_Inspector_RulesDB_Adapter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_RulesDB_Adapter.java
@@ -13,6 +13,20 @@ import android.widget.TextView;
  * Created by Mike092015 on 25/02/2016.
  */
 public class Database_Inspector_RulesDB_Adapter extends CursorAdapter {
+    public static int ruleidoffset;
+    public static int rulenameoffset;
+    public static int ruletypeoffset;
+    public static int rulepromptflagoffset;
+    public static int ruleperiodoffset;
+    public static int rulemultiplieroffset;
+    public static int ruleactiveonoffset;
+    public static int ruleproductrefoffset;
+    public static int ruleaislerefoffset;
+    public static int ruleusesoffset;
+    public static int rulenumbertogetoffset;
+    public static int rulemincostoffset;
+    public static int rulemaxcostoffset;
+
     public Database_Inspector_RulesDB_Adapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -29,6 +43,21 @@ public class Database_Inspector_RulesDB_Adapter extends CursorAdapter {
     }
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            ruleidoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_ID);
+            rulenameoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_NAME);
+            ruletypeoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_TYPE);
+            rulepromptflagoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PROMPTFLAG);
+            ruleperiodoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PERIOD);
+            rulemultiplieroffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MULTIPLIER);
+            ruleactiveonoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_ACTIVEON);
+            ruleproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PRODUCTREF);
+            ruleaislerefoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_AISLEREF);
+            ruleusesoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_USES);
+            rulenumbertogetoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_NUMBERTOGET);
+            rulemincostoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MINCOST);
+            rulemaxcostoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MAXCOST);
+        }
         TextView textviewrulesid = (TextView) view.findViewById(R.id.adire_rulesdb_id);
         TextView textviewrulesrulename = (TextView) view.findViewById(R.id.adire_rulesdb_rulename);
         TextView textviewrulesruletype = (TextView) view.findViewById(R.id.adire_rulesdb_ruletype);
@@ -42,19 +71,18 @@ public class Database_Inspector_RulesDB_Adapter extends CursorAdapter {
         TextView textviewrulesmincost = (TextView) view.findViewById(R.id.adire_rulesdb_mincost);
         TextView textviewrulesmaxcost = (TextView) view.findViewById(R.id.adire_rulesdb_maxcost);
 
-        textviewrulesid.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_ID_INDEX));
-        textviewrulesrulename.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_NAME_INDEX));
-        textviewrulesruletype.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_TYPE_INDEX));
-        textviewrulesrulepromtflag.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_PROMPTFLAG_INDEX));
-        textviewrulesruleperiod.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_PERIOD_INDEX));
-        textviewrulesrulemultiplier.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_MULTIPLIER_INDEX));
-        textviewrulesruleactiveon.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_ACTIVEON_INDEX));
-        textviewrulesruleproductref.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_PRODUCTREF_INDEX));
-        textviewrulesruleaisleref.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_AISLEREF_INDEX));
-        textviewrulesruleuses.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_USES_INDEX));
-        textviewrulesruleactiveon.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_ACTIVEON_INDEX));
-        textviewrulesmincost.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_MINCOST_INDEX));
-        textviewrulesmaxcost.setText(cursor.getString(ShopperDBHelper.RULES_COLUMN_MAXCOST_INDEX));
+        textviewrulesid.setText(cursor.getString(ruleidoffset));
+        textviewrulesrulename.setText(cursor.getString(rulenameoffset));
+        textviewrulesruletype.setText(cursor.getString(ruletypeoffset));
+        textviewrulesrulepromtflag.setText(cursor.getString(rulepromptflagoffset));
+        textviewrulesruleperiod.setText(cursor.getString(ruleperiodoffset));
+        textviewrulesrulemultiplier.setText(cursor.getString(rulemultiplieroffset));
+        textviewrulesruleactiveon.setText(cursor.getString(ruleactiveonoffset));
+        textviewrulesruleproductref.setText(cursor.getString(ruleproductrefoffset));
+        textviewrulesruleaisleref.setText(cursor.getString(ruleaislerefoffset));
+        textviewrulesruleuses.setText(cursor.getString(ruleusesoffset));
+        textviewrulesmincost.setText(cursor.getString(rulemincostoffset));
+        textviewrulesmaxcost.setText(cursor.getString(rulemaxcostoffset));
 
     }
     @Override

--- a/app/src/main/java/mjt/shopper/Database_Inspector_ShopListDB_Adapter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_ShopListDB_Adapter.java
@@ -14,6 +14,16 @@ import java.text.NumberFormat;
  * Created by Mike092015 on 8/03/2016.
  */
 public class Database_Inspector_ShopListDB_Adapter extends CursorAdapter {
+    public static int shoplistidoffset;
+    public static int shoplistproductrefoffset;
+    public static int shoplistdateaddedoffset;
+    public static int shoplistnumbertogetoffset;
+    public static int shoplistdoneoffset;
+    public static int shoplistdategotoffset;
+    public static int shoplistcostoffset;
+    public static int shoplistproductusagerefoffset;
+    public static int shoplistaislerefoffset;
+
     public Database_Inspector_ShopListDB_Adapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, FLAG_REGISTER_CONTENT_OBSERVER);
     }
@@ -31,6 +41,17 @@ public class Database_Inspector_ShopListDB_Adapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            shoplistidoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_ID);
+            shoplistproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_PRODUCTREF);
+            shoplistdateaddedoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_DATEADDED);
+            shoplistnumbertogetoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_NUMBERTOGET);
+            shoplistdoneoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_DONE);
+            shoplistdategotoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_DATEGOT);
+            shoplistcostoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_COST);
+            shoplistproductusagerefoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_PRODUCTUSAGEREF);
+            shoplistproductusagerefoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_AISLEREF);
+        }
         TextView tvshoplistid = (TextView) view.findViewById(R.id.adise_shoplistdb_id);
         TextView tvshoplistproductref = (TextView) view.findViewById(R.id.adise_shoplistdb_productref);
         TextView tvshoplistdateadded = (TextView) view.findViewById(R.id.adise_shoplistdb_dateadded);
@@ -41,15 +62,15 @@ public class Database_Inspector_ShopListDB_Adapter extends CursorAdapter {
         TextView tvshoplistproductusageref = (TextView) view.findViewById(R.id.adise_shoplistdb_productusageref);
         TextView tvshoplistaisleref = (TextView) view.findViewById(R.id.adise_shoplistdb_aisleref);
 
-        tvshoplistid.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_ID_INDEX));
-        tvshoplistproductref.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_PRODUCTREF_INDEX));
-        tvshoplistdateadded.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_DATEADDED_INDEX));
-        tvshoplistnumbertoget.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_NUMBERTOGET_INDEX));
-        tvshoplistdone.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_DONE_INDEX));
-        tvshoplistdategot.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_DATEGOT_INDEX));
-        tvshoplistcost.setText(NumberFormat.getCurrencyInstance().format(cursor.getFloat(ShopperDBHelper.SHOPLIST_COLUMN_COST_INDEX)));
-        tvshoplistproductusageref.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_PRODUCTUSAGEREF_INDEX));
-        tvshoplistaisleref.setText(cursor.getString(ShopperDBHelper.SHOPLIST_COLUMN_AISLEREF_INDEX));
+        tvshoplistid.setText(cursor.getString(shoplistidoffset));
+        tvshoplistproductref.setText(cursor.getString(shoplistproductrefoffset));
+        tvshoplistdateadded.setText(cursor.getString(shoplistdateaddedoffset));
+        tvshoplistnumbertoget.setText(cursor.getString(shoplistnumbertogetoffset));
+        tvshoplistdone.setText(cursor.getString(shoplistdoneoffset));
+        tvshoplistdategot.setText(cursor.getString(shoplistdategotoffset));
+        tvshoplistcost.setText(NumberFormat.getCurrencyInstance().format(cursor.getFloat(shoplistcostoffset)));
+        tvshoplistproductusageref.setText(cursor.getString(shoplistproductusagerefoffset));
+        tvshoplistaisleref.setText(cursor.getString(shoplistaislerefoffset));
     }
 
     @Override

--- a/app/src/main/java/mjt/shopper/Database_Inspector_ShopsDB_Adapter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_ShopsDB_Adapter.java
@@ -13,6 +13,15 @@ import android.widget.TextView;
  * Created by Mike092015 on 17/02/2016.
  */
 class Database_Inspector_ShopsDB_Adapter extends CursorAdapter {
+    public static int storeidfoffset;
+    public static int storenameoffset;
+    public static int storeorderoffset;
+    public static int storestreetofffset;
+    public static int storecityoffset;
+    public static int storestateoffset;
+    public static int storephoneoffset;
+    public static int storenotesoffset;
+
     public Database_Inspector_ShopsDB_Adapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -33,6 +42,18 @@ class Database_Inspector_ShopsDB_Adapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        // get column offsets from cursor (once to reduce overheads)
+        if(cursor.getPosition() == 0 ) {
+            storeidfoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ID);
+            storenameoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            storeorderoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ORDER);
+            storestreetofffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+            storecityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            storestateoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STATE);
+            storephoneoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_PHONE);
+            storenotesoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NOTES);
+        }
+
         TextView textviewshopid = (TextView) view.findViewById(R.id.adise_shopsdb_id);
         TextView textviewshoporder = (TextView) view.findViewById(R.id.adise_shopsdb_order);
         TextView textviewshopname = (TextView) view.findViewById(R.id.adise_shopsdb_shopname);
@@ -42,14 +63,14 @@ class Database_Inspector_ShopsDB_Adapter extends CursorAdapter {
         TextView textviewshopphone = (TextView) view.findViewById(R.id.adise_shopsdb_phone);
         TextView textviewshopnotes = (TextView) view.findViewById(R.id.adise_shopsdb_notes);
 
-        textviewshopid.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMNN_ID_INDEX));
-        textviewshoporder.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_ORDER_INDEX));
-        textviewshopname.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_NAME_INDEX));
-        textviewshopstreet.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_STREET_INDEX));
-        textviewshopcity.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_CITY_INDEX));
-        textviewshopstate.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_STATE_INDEX));
-        textviewshopphone.setText(cursor.getString(ShopperDBHelper.SHOPS_COULMN_PHONE_INDEX));
-        textviewshopnotes.setText(cursor.getString(ShopperDBHelper.SHOPS_COULMN_NOTES_INDEX));
+        textviewshopid.setText(cursor.getString(storeidfoffset));
+        textviewshoporder.setText(cursor.getString(storeorderoffset));
+        textviewshopname.setText(cursor.getString(storenameoffset));
+        textviewshopstreet.setText(cursor.getString(storestreetofffset));
+        textviewshopcity.setText(cursor.getString(storecityoffset));
+        textviewshopstate.setText(cursor.getString(storestateoffset));
+        textviewshopphone.setText(cursor.getString(storephoneoffset));
+        textviewshopnotes.setText(cursor.getString(storenotesoffset));
     }
 
     @Override

--- a/app/src/main/java/mjt/shopper/Database_Inspector_ValuesDB_Adapter.java
+++ b/app/src/main/java/mjt/shopper/Database_Inspector_ValuesDB_Adapter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
+import android.view.SurfaceHolder;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CursorAdapter;
@@ -13,6 +14,15 @@ import android.widget.TextView;
  * Created by Mike092015 on 30/03/2016.
  */
 public class Database_Inspector_ValuesDB_Adapter extends CursorAdapter {
+    public static int valuesidoffset;
+    public static int valuesnameoffset;
+    public static int valuestypeoffset;
+    public static int valuesintoffset;
+    public static int valuesrealoffset;
+    public static int valuestextoffset;
+    public static int valuesincludeinsettingsoffset;
+    public static int valuessettingsinfooffset;
+
     public Database_Inspector_ValuesDB_Adapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -29,6 +39,16 @@ public class Database_Inspector_ValuesDB_Adapter extends CursorAdapter {
     }
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if (cursor.getPosition() == 0 ) {
+            valuesidoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_ID);
+            valuesnameoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUENAME);
+            valuestypeoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUETYPE);
+            valuesintoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUEINT);
+            valuesrealoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUEREAL);
+            valuestextoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUETEXT);
+            valuesincludeinsettingsoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUEINCLUDEINSETTINGS);
+            valuessettingsinfooffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUESETTINGSINFO);
+        }
         TextView textviewvalueid = (TextView) view.findViewById(R.id.adi_appvaluesdb_valueid);
         TextView textviewvaluename = (TextView) view.findViewById(R.id.adi_appvaluesdb_valuename);
         TextView textviewvaluetype = (TextView) view.findViewById(R.id.adi_appvaluesdb_valuetype);
@@ -38,14 +58,14 @@ public class Database_Inspector_ValuesDB_Adapter extends CursorAdapter {
         TextView textviewvaluesettingsincl = (TextView) view.findViewById(R.id.adi_appvaluesdb_valueincludeinsettings);
         TextView textviewvaluesettingsinfo = (TextView) view.findViewById(R.id.adi_appvaluesdb_settingsinfo);
 
-        textviewvalueid.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_ID_INDEX));
-        textviewvaluename.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUENAME_INDEX));
-        textviewvaluetype.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUETYPE_INDDEX));
-        textviewvalueint.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUEINT_INDEX));
-        textviewvaluereal.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUEREAL_INDEX));
-        textviewvaluestr.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUETEXT_INDEX));
-        textviewvaluesettingsincl.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUEINCLUDEINSETTINGS_INDEX));
-        textviewvaluesettingsinfo.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUESETTINGSINFO_INDEX));
+        textviewvalueid.setText(cursor.getString(valuesidoffset));
+        textviewvaluename.setText(cursor.getString(valuesnameoffset));
+        textviewvaluetype.setText(cursor.getString(valuestypeoffset));
+        textviewvalueint.setText(cursor.getString(valuesintoffset));
+        textviewvaluereal.setText(cursor.getString(valuesrealoffset));
+        textviewvaluestr.setText(cursor.getString(valuestextoffset));
+        textviewvaluesettingsincl.setText(cursor.getString(valuesincludeinsettingsoffset));
+        textviewvaluesettingsinfo.setText(cursor.getString(valuessettingsinfooffset));
     }
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {

--- a/app/src/main/java/mjt/shopper/MainActivity.java
+++ b/app/src/main/java/mjt/shopper/MainActivity.java
@@ -15,13 +15,27 @@ import android.widget.Toast;
 import java.io.File;
 import java.util.Date;
 
+// MainActivity - Application Starts Here
+// Perform inital checks
+// Database exists, if not creates database
+// Retrieves Settings (Disable Help Screens boolean and Developermode boolean)
+// Gets database stats (row counts of the tables), displays them id inn developer mode
+// Displays context relevant buttons including extra buttons if in developer mode
+// Compore actual DB against design and add tables/columns if necessary
+// If no stores then invoke add store directly
+// Setup Values table (if already done then duplicates won't be added)
+// Button handling as per xml then handle selection of options
 public class MainActivity extends AppCompatActivity {
-    private final static String THIS_ACTIVITY = "MainActivity";
+
+    // Activity/Shared preferences variables
+    private final static String THIS_ACTIVITY = "MainActivity"; // Allows ActivityNsame to be sent
     private SharedPreferences sharedPreferences;
     private boolean developermode = false;
     private boolean helpoffmode = false;
+    //private boolean developermode;
 
 
+    // Data/DB variables (generally in unset state)
     public ShopperDBHelper shopperdb = new ShopperDBHelper(this,null,null,1);
     private int shopcount;
     private int aislecount;
@@ -29,6 +43,8 @@ public class MainActivity extends AppCompatActivity {
     private int productsinaisles;
     private int rulecount;
     private int shoppinglistcount;
+
+    // View variables (in unset state)
     private TextView stats;
     private TextView storesbutton;
     private TextView storeshelpbutton;
@@ -46,7 +62,6 @@ public class MainActivity extends AppCompatActivity {
     private TextView dbdatahelpbutton;
     private TextView dbschemabutton;
     private TextView dbschemahelpbutton;
-    private boolean devmode;
 
     //==============================================================================================
     //==============================================================================================
@@ -59,14 +74,18 @@ public class MainActivity extends AppCompatActivity {
         actionBar.setDisplayHomeAsUpEnabled(false);
         PreferenceManager.setDefaultValues(this, R.xml.usersettings, false);
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        devmode = sharedPreferences.getBoolean(getResources().getString(R.string.sharedpreferencekey_developermode), false);
+        developermode = sharedPreferences.getBoolean(getResources().getString(R.string.sharedpreferencekey_developermode), false);
         helpoffmode = sharedPreferences.getBoolean(getResources().getString(R.string.sharedpreferencekey_showhelpmode), false);
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG, "Primary Activity Initialisation Complete", THIS_ACTIVITY, "onCreate",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,
+                "Primary Activity Initialisation Complete", THIS_ACTIVITY, "onCreate",developermode);
 
         // Check to see if database exists
         if(!doesDatabaseExist(this,ShopperDBHelper.DATABASE_NAME)) {
-            Toast.makeText(this,"Welcome to Shopper. Creating Shopper Database and underlying tables.",Toast.LENGTH_LONG).show();
-            mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG, "Shopper Database will be created as it didn't exist", THIS_ACTIVITY, "onCreate",devmode);
+            Toast.makeText(this,"Welcome to Shopper. Creating Shopper Database and underlying tables.",
+                    Toast.LENGTH_LONG).show();
+            mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,
+                    "Shopper Database will be created as it didn't exist",
+                    THIS_ACTIVITY, "onCreate",developermode);
         }
 
         // Get Button id's
@@ -88,12 +107,12 @@ public class MainActivity extends AppCompatActivity {
         dbschemahelpbutton = (TextView) this.findViewById(R.id.am_schemahelp_button);
         stats = (TextView) this.findViewById(R.id.amtv30);
 
+        // Perform Initialisation
         getSettings();
         handleStats();
         selectButtons();
         initialisationChecks();
         ShopperDBHelper valuesdb = new ShopperDBHelper(this,null,null,1);
-
 
 
         //Setup AutoAdd Periods for dropdown selection
@@ -111,17 +130,23 @@ public class MainActivity extends AppCompatActivity {
         valuesdb.close();
     }
 
+    //==============================================================================================
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"onCreateOptionsMenu",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"onCreateOptionsMenu",developermode);
+        super.onCreateOptionsMenu(menu);
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.usersettingsmenu, menu);
         return true;
     }
 
+    //==============================================================================================
     @Override
     public boolean onOptionsItemSelected(MenuItem menuItem) {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"onOptionsItemSelected",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"onOptionsItemSelected",developermode);
+        super.onOptionsItemSelected(menuItem);
         Intent intent = new Intent(this,UserSettings.class);
         startActivity(intent);
         return true;
@@ -130,7 +155,8 @@ public class MainActivity extends AppCompatActivity {
     //==============================================================================================
     @Override
     protected  void onResume() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"onResume",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"onResume",developermode);
         super.onResume();
         getSettings();
         handleStats();
@@ -140,13 +166,20 @@ public class MainActivity extends AppCompatActivity {
     //==============================================================================================
     @Override
     protected void onDestroy() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"onDestroy",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"onDestroy",developermode);
         //SQLiteStudioService.instance().stop();
         super.onDestroy();
         shopperdb.close();
     }
+
+    //==============================================================================================
+    // retrieve settings from sharedpreferences
+    // developer mode boolean if on turns on extra logging and addtitional main display options
+    // helpoffmode if on turns off help displays
     private void getSettings() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"getSettings",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"getSettings",developermode);
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         developermode = sharedPreferences.getBoolean(getString(R.string.sharedpreferencekey_developermode),false);
         helpoffmode = sharedPreferences.getBoolean(getString(R.string.sharedpreferencekey_showhelpmode),false);
@@ -154,8 +187,14 @@ public class MainActivity extends AppCompatActivity {
 
     //==============================================================================================
     // Select Buttons that are to be dissplayed
+    // Displays buttons relevant to the current state/context i.e. DB state and developermode
+    // e.g. if no stores or products then only Stores and Products buttons as other information is
+    // dependany up stores or products (and so on as per comments)
+    // developer mode is independant of stores/products etc if true then display DATA and SCHEMA
+    // buttons else display neither.
     private void selectButtons() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"selectButtons",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"selectButtons",developermode);
 
         // Always show Stores Button
         storesbutton.setVisibility(View.VISIBLE);
@@ -186,8 +225,8 @@ public class MainActivity extends AppCompatActivity {
             productshelpbutton.setVisibility(View.GONE);
         }
 
-
-        // Only Show ProductUsage button if products exist
+        // Only Show ProductUsage (TO GET) and Rules buttons if products are in aisles
+        // This requires products and aisles to exist
         if(productcount < 1  | productcount < 1 | aislecount < 1 | productsinaisles < 1) {
             productusagebutton.setVisibility(View.GONE);
             productusagehelpbutton.setVisibility(View.GONE);
@@ -244,7 +283,8 @@ public class MainActivity extends AppCompatActivity {
     // Get statistics # of shops, aisles, products, products in aisles, rules and shopping list entries.
     // Also show date and time and then timestamp. Only shown in developer mode.
     private void handleStats() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"handleStats",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"handleStats",developermode);
 
         shopcount = shopperdb.numberOfShops();
         aislecount = shopperdb.numberOfAisles();
@@ -277,7 +317,8 @@ public class MainActivity extends AppCompatActivity {
     // expand database (add any new tables and/or columns)
     // if no stores(shops) then invoke store add
     private void initialisationChecks() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"initialisationChecks",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"initialisationChecks",developermode);
 
         ShopperDBHelper shopperdb = new ShopperDBHelper(this,null,null,1);
         shopperdb.onExpand();
@@ -291,9 +332,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     //==============================================================================================
-    // Button Clicks Handled Here
+    // Button Clicks Handled Here note onClick instigated via layout
     public void buttonClicked(View view) {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"buttonClicked",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"buttonClicked",developermode);
 
         switch (view.getId()) {
             case R.id.am_stores_button:
@@ -344,6 +386,7 @@ public class MainActivity extends AppCompatActivity {
                 intent.putExtra("DEVELOPERMODE",developermode);
                 startActivity(intent);
                 break;
+            // Note redundant as removed from layout
             case R.id.am_storeshelp_button:
                 break;
             case R.id.am_aisleshelp_button:
@@ -365,21 +408,26 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    @Override
-    public void onStart() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"onStart",devmode);
-        super.onStart();
-    }
-
-    @Override
-    public void onStop() {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"onStop",devmode);
-        super.onStop();
-    }
-
+    // Check if Database exists
     public boolean doesDatabaseExist(Context context, String dbName) {
-        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",THIS_ACTIVITY,"doesDatabaseExist",devmode);
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"doesDatabaseExist",developermode);
         File dbFile = context.getDatabasePath(dbName);
         return dbFile.exists();
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Unimplemented/Unused methods
+    @Override
+    public void onStart() {
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"onStart",developermode);
+        super.onStart();
+    }
+    @Override
+    public void onStop() {
+        mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
+                THIS_ACTIVITY,"onStop",developermode);
+        super.onStop();
     }
 }

--- a/app/src/main/java/mjt/shopper/MainActivity.java
+++ b/app/src/main/java/mjt/shopper/MainActivity.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -13,6 +14,11 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.util.Date;
 
 // MainActivity - Application Starts Here
@@ -322,6 +328,26 @@ public class MainActivity extends AppCompatActivity {
 
         ShopperDBHelper shopperdb = new ShopperDBHelper(this,null,null,1);
         shopperdb.onExpand();
+        //File path = getFilesDir();
+        //File file = new File(path,"ShopperExportSQL.txt");
+        //Log.d("ShopperExport","Starting Shopper Export Test");
+        //try {
+        //    Log.d("ShopperExport","Trying PrinWriter Method");
+        //    FileOutputStream fos = new FileOutputStream(file);
+        //    //PrintWriter pw = new PrintWriter(fos);
+        //    //pw.write("Testing");
+        //    //pw.flush();
+        //    //pw.close();
+        //    //fos.close();
+        //    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fos);
+        //    outputStreamWriter.write("TestDate");
+        //    outputStreamWriter.close();
+        //    fos.close();
+        //}
+        //catch (IOException e) {
+        //    Log.e("Exception", "File Write Failed " + e.toString());
+        //}
+        //Log.d("ShopperExport","Ended Shopper Export Test");
 
         if(shopcount < 1 ) {
             Intent intent = new Intent(this, ShopAddActivity.class);

--- a/app/src/main/java/mjt/shopper/ProductListSpinnerAdapter.java
+++ b/app/src/main/java/mjt/shopper/ProductListSpinnerAdapter.java
@@ -12,6 +12,13 @@ import android.widget.TextView;
  * Created by Mike092015 on 14/02/2016.
  */
 public class ProductListSpinnerAdapter extends CursorAdapter{
+    public static int productidoffset;
+    public static int productnameoffset;
+    public static int productorderoffset;
+    public static int productaisleoffset;
+    public static int productnotesoffset;
+    public static int productusesoffset;
+
     public ProductListSpinnerAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -22,6 +29,14 @@ public class ProductListSpinnerAdapter extends CursorAdapter{
     }
     @Override
     public void bindView(View view,Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            productidoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ID);
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            productorderoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ORDER);
+            productaisleoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_AISLE);
+            productnotesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NOTES);
+            productusesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_USES);
+        }
         TextView textviewproductid = (TextView) view.findViewById(R.id.product_id_entry);
         TextView textviewproductname = (TextView) view.findViewById(R.id.product_name_entry);
         TextView textviewproductorder = (TextView) view.findViewById(R.id.product_order_entry);
@@ -29,15 +44,15 @@ public class ProductListSpinnerAdapter extends CursorAdapter{
         TextView textviewproductnotes = (TextView) view.findViewById(R.id.product_notes_entry);
         TextView textviewproductuses = (TextView) view.findViewById(R.id.product_uses_entry);
 
-        textviewproductid.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ID_INDEX));
+        textviewproductid.setText(cursor.getString(productidoffset));
         textviewproductid.setVisibility(View.GONE);
-        textviewproductname.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NAME_INDEX));
-        textviewproductorder.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ORDER_INDEX));
+        textviewproductname.setText(cursor.getString(productnameoffset));
+        textviewproductorder.setText(cursor.getString(productorderoffset));
         textviewproductorder.setVisibility(View.GONE);
-        textviewproductaisleref.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_AISLE_INDEX));
+        textviewproductaisleref.setText(cursor.getString(productaisleoffset));
         textviewproductaisleref.setVisibility(View.GONE);
-        textviewproductuses.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_USES_INDEX));
+        textviewproductuses.setText(cursor.getString(productusesoffset));
         textviewproductuses.setVisibility(View.GONE);
-        textviewproductnotes.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NOTES_INDEX));
+        textviewproductnotes.setText(cursor.getString(productnotesoffset));
     }
 }

--- a/app/src/main/java/mjt/shopper/ProductsCursorAdapter.java
+++ b/app/src/main/java/mjt/shopper/ProductsCursorAdapter.java
@@ -13,6 +13,13 @@ import android.widget.TextView;
  * Created by Mike092015 on 9/02/2016.
  */
 public class ProductsCursorAdapter extends CursorAdapter {
+    public static int productidoffset;
+    public static int productnameoffset;
+    public static int productorderoffset;
+    public static int productaisleoffset;
+    public static int productnotesoffset;
+    public static int productusesoffset;
+
     public ProductsCursorAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
 
@@ -31,6 +38,14 @@ public class ProductsCursorAdapter extends CursorAdapter {
     }
     @Override
     public void bindView(View view,Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            productidoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ID);
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            productorderoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ORDER);
+            productaisleoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_AISLE);
+            productnotesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NOTES);
+            productusesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_USES);
+        }
         TextView textviewproductid = (TextView) view.findViewById(R.id.product_id_entry);
         TextView textviewproductname = (TextView) view.findViewById(R.id.product_name_entry);
         TextView textviewproductorder = (TextView) view.findViewById(R.id.product_order_entry);
@@ -38,12 +53,12 @@ public class ProductsCursorAdapter extends CursorAdapter {
         TextView textviewproductnotes = (TextView) view.findViewById(R.id.product_notes_entry);
         TextView textviewproductuses = (TextView) view.findViewById(R.id.product_uses_entry);
 
-        textviewproductid.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ID_INDEX));
-        textviewproductname.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NAME_INDEX));
-        textviewproductorder.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ORDER_INDEX));
-        textviewproductaisleref.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_AISLE_INDEX));
-        textviewproductuses.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_USES_INDEX));
-        textviewproductnotes.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NOTES_INDEX));
+        textviewproductid.setText(cursor.getString(productidoffset));
+        textviewproductname.setText(cursor.getString(productnameoffset));
+        textviewproductorder.setText(cursor.getString(productorderoffset));
+        textviewproductaisleref.setText(cursor.getString(productaisleoffset));
+        textviewproductuses.setText(cursor.getString(productusesoffset));
+        textviewproductnotes.setText(cursor.getString(productnotesoffset));
 
     }
     @Override

--- a/app/src/main/java/mjt/shopper/ProductsPerAisleCursorAdapter.java
+++ b/app/src/main/java/mjt/shopper/ProductsPerAisleCursorAdapter.java
@@ -16,6 +16,20 @@ import java.text.NumberFormat;
  * Created by Mike092015 on 27/02/2016.
  */
 public class ProductsPerAisleCursorAdapter extends CursorAdapter implements Serializable {
+    public static int productidoffset;
+    public static int productnameoffset;
+    public static int productorderoffset;
+    public static int productaisleoffset;
+    public static int productusesoffset;
+    public static int productnotesoffset;
+    public static int productusageaislerefoffset;
+    public static int productusageproductrefoffset;
+    public static int productusagecostoffset;
+    public static int productusagebuycountoffset;
+    public static int productusagefirstbuydateoffset;
+    public static int productusagelastbuydateoffset;
+    public static int productusagemincostoffset;
+    public static int productusageorderinaisleoffset;
     public ProductsPerAisleCursorAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, FLAG_REGISTER_CONTENT_OBSERVER);
     }
@@ -34,6 +48,22 @@ public class ProductsPerAisleCursorAdapter extends CursorAdapter implements Seri
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            productidoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ID);
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            productorderoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ORDER);
+            productaisleoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_AISLE);
+            productusesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NOTES);
+            productnotesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NOTES);
+            productusageaislerefoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_AISLEREF);
+            productusageproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_PRODUCTREF);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST);
+            productusagebuycountoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_BUYCOUNT);
+            productusagefirstbuydateoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_FIRSTBUYDATE);
+            productusagelastbuydateoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_LATESTBUYDATE);
+            productusagemincostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_MINCOST);
+            productusageorderinaisleoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_ORDER);
+        }
         TextView textviewproductid = (TextView) view.findViewById(R.id.product_id_entry);
         TextView textviewproductname = (TextView) view.findViewById(R.id.product_name_entry);
         TextView textviewproductorder = (TextView) view.findViewById(R.id.product_order_entry);
@@ -49,21 +79,20 @@ public class ProductsPerAisleCursorAdapter extends CursorAdapter implements Seri
         TextView textviewproductusagemincost = (TextView) view.findViewById(R.id.productusage_mincost_entry);
         TextView textviewproductusageorderinaisle = (TextView) view.findViewById(R.id.productusage_orderinaisle_entry);
 
-        textviewproductid.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ID_INDEX));
-        textviewproductname.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NAME_INDEX));
-        textviewproductorder.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_ORDER_INDEX));
-        textviewproductasile.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_AISLE_INDEX));
-        textviewproductuses.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_USES_INDEX));
-        textviewproductnotes.setText(cursor.getString(ShopperDBHelper.PRODUCTS_COLUMN_NOTES_INDEX));
-        int joinoffset = ShopperDBHelper.PRODUCTS_COLUMN_NOTES_INDEX + 1;
-        textviewproductusageaisleref.setText(cursor.getString((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_AISLEREF_INDEX)));
-        textviewproductusageproductref.setText(cursor.getString((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_PRODUCTREF_INDEX)));
-        textviewproductusagecost.setText((NumberFormat.getCurrencyInstance().format(cursor.getFloat((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST_INDEX)))));
-        textviewproductusagebuycount.setText(cursor.getString((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_BUYCOUNT_INDEX)));
-        textviewproductusagefirstbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT,cursor.getLong((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_FIRSTBUYDATE_INDEX))));
-        textviewproductusagelastbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT, cursor.getLong((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_LASTBUYDATE_INDEX))));
-        textviewproductusagemincost.setText(cursor.getString((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_MINCOST_INDEX)));
-        textviewproductusageorderinaisle.setText(cursor.getString((joinoffset + ShopperDBHelper.PRODUCTUSAGE_COLUMN_ORDER_INDEX)));
+        textviewproductid.setText(cursor.getString(productidoffset));
+        textviewproductname.setText(cursor.getString(productnameoffset));
+        textviewproductorder.setText(cursor.getString(productorderoffset));
+        textviewproductasile.setText(cursor.getString(productaisleoffset));
+        textviewproductuses.setText(cursor.getString(productusesoffset));
+        textviewproductnotes.setText(cursor.getString(productnotesoffset));
+        textviewproductusageaisleref.setText(cursor.getString(productusageaislerefoffset));
+        textviewproductusageproductref.setText(cursor.getString(productusageproductrefoffset));
+        textviewproductusagecost.setText((NumberFormat.getCurrencyInstance().format(cursor.getFloat(productusagecostoffset))));
+        textviewproductusagebuycount.setText(cursor.getString(productusagebuycountoffset));
+        textviewproductusagefirstbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT,cursor.getLong(productusagefirstbuydateoffset)));
+        textviewproductusagelastbuydate.setText(DateFormat.format(Constants.STANDARD_DDMMYYY_FORMAT, cursor.getLong(productusagelastbuydateoffset)));
+        textviewproductusagemincost.setText(cursor.getString(productusagemincostoffset));
+        textviewproductusageorderinaisle.setText(cursor.getString(productusageorderinaisleoffset));
     }
 
     @Override

--- a/app/src/main/java/mjt/shopper/PurchaseableProductsAdapter.java
+++ b/app/src/main/java/mjt/shopper/PurchaseableProductsAdapter.java
@@ -15,6 +15,16 @@ import java.text.NumberFormat;
  * Created by Mike092015 on 16/03/2016.
  */
 public class PurchaseableProductsAdapter extends CursorAdapter {
+    public static int productusageaislerefoffest;
+    public static int productusageproductrefoffset;
+    public static int productusagecostoffset;
+    public static int productidoffset;
+    public static int productnameoffset;
+    public static int aisleidoffset;
+    public static int aislenameoffset;
+    public static int shopnameofffset;
+    public static int shopcityoffset;
+    public static int shopstreetoffset;
     public PurchaseableProductsAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -34,6 +44,18 @@ public class PurchaseableProductsAdapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            productusageaislerefoffest = cursor.getColumnIndex("_ID"); // Note! SQL uses AS _ID
+            productusageproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_AISLEREF);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST);
+            productidoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_TABLE_NAME+ShopperDBHelper.PRODUCTS_COLUMN_ID);
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            aisleidoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_TABLE_NAME+ShopperDBHelper.AISLES_COLUMN_ID);
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            shopnameofffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            shopcityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            shopstreetoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+        }
         TextView tvproductname = (TextView) view.findViewById(R.id.product_name_entry);
         TextView tvshopname = (TextView) view.findViewById(R.id.shop_name_entry);
         TextView tvshopcity = (TextView) view.findViewById(R.id.shop_city_entry);
@@ -41,12 +63,12 @@ public class PurchaseableProductsAdapter extends CursorAdapter {
         TextView tvaislename = (TextView) view.findViewById(R.id.aisle_name_entry);
         TextView tvcost = (TextView) view.findViewById(R.id.cost_entry);
 
-        tvproductname.setText(cursor.getString(4));
-        tvshopname.setText(cursor.getString(7));
-        tvshopcity.setText(cursor.getString(8));
-        tvshopstreet.setText(cursor.getString(9));
-        tvaislename.setText(cursor.getString(6));
-        tvcost.setText(NumberFormat.getCurrencyInstance().format(cursor.getDouble(2)));
+        tvproductname.setText(cursor.getString(productnameoffset));
+        tvshopname.setText(cursor.getString(shopnameofffset));
+        tvshopcity.setText(cursor.getString(shopcityoffset));
+        tvshopstreet.setText(cursor.getString(shopstreetoffset));
+        tvaislename.setText(cursor.getString(aislenameoffset));
+        tvcost.setText(NumberFormat.getCurrencyInstance().format(cursor.getDouble(productusagecostoffset)));
     }
 
     @Override

--- a/app/src/main/java/mjt/shopper/RuleAddEditPeriodSpinnerCursorAdapter.java
+++ b/app/src/main/java/mjt/shopper/RuleAddEditPeriodSpinnerCursorAdapter.java
@@ -13,11 +13,15 @@ import android.widget.TextView;
  */
 
 public class RuleAddEditPeriodSpinnerCursorAdapter extends CursorAdapter {
+    public static int valuetextdataoffset;
     public RuleAddEditPeriodSpinnerCursorAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            valuetextdataoffset = cursor.getColumnIndex(ShopperDBHelper.VALUES_COLUMN_VALUETEXT);
+        }
         //TextView textviewvalueid = (TextView) view.findViewById(R.id.adi_appvaluesdb_valueid);
         //TextView textviewvaluename = (TextView) view.findViewById(R.id.adi_appvaluesdb_valuename);
         //TextView textviewvaluetype = (TextView) view.findViewById(R.id.adi_appvaluesdb_valuetype);
@@ -32,7 +36,7 @@ public class RuleAddEditPeriodSpinnerCursorAdapter extends CursorAdapter {
         //textviewvaluetype.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUETYPE_INDDEX));
         //textviewvalueint.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUEINT_INDEX));
         //textviewvaluereal.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUEREAL_INDEX));
-        textviewvaluestr.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUETEXT_INDEX));
+        textviewvaluestr.setText(cursor.getString(valuetextdataoffset));
         //textviewvaluesettingsincl.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUEINCLUDEINSETTINGS_INDEX));
         //textviewvaluesettingsinfo.setText(cursor.getString(ShopperDBHelper.VALUES_COLUMN_VALUESETTINGSINFO_INDEX));
     }

--- a/app/src/main/java/mjt/shopper/RuleListAdapter.java
+++ b/app/src/main/java/mjt/shopper/RuleListAdapter.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.view.LayoutInflater;
+import android.view.SurfaceHolder;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckedTextView;
@@ -19,6 +20,26 @@ import java.text.SimpleDateFormat;
 public class RuleListAdapter extends CursorAdapter {
 
     public SimpleDateFormat sdf = new SimpleDateFormat(Constants.EXTENDED__DATE_DORMAT);
+    public static int ruleidoffset;
+    public static int rulenameoffset;
+    public static int ruletyoeoffset;
+    public static int rulepromptflagoffset;
+    public static int ruleperiodoffset;
+    public static int rulemultiplieroffset;
+    public static int ruleactiveonoffset;
+    public static int ruleproductrefoffset;
+    public static int ruleaislerefoffset;
+    public static int ruleusesoffset;
+    public static int rulenumbertogetoffset;
+    public static int rulemincostoffset;
+    public static int rulemaxcostoffset;
+    public static int productnameoffset;
+    public static int aislenameoffset;
+    public static int aisleshoprefoffset;
+    public static int storenameoffset;
+    public static int storecityoffset;
+    public static int storestreetoffset;
+    public static int productusagecostoffset;
 
     public RuleListAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, FLAG_REGISTER_CONTENT_OBSERVER);
@@ -40,27 +61,49 @@ public class RuleListAdapter extends CursorAdapter {
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
         int pos = cursor.getPosition();
+        if(pos == 0) {
+            ruleidoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_ID);
+            rulenameoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_NAME);
+            ruletyoeoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_TYPE);
+            rulepromptflagoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PROMPTFLAG);
+            ruleperiodoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PERIOD);
+            rulemultiplieroffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MULTIPLIER);
+            ruleactiveonoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_ACTIVEON);
+            ruleproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PRODUCTREF);
+            ruleaislerefoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_AISLEREF);
+            ruleusesoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_USES);
+            rulenumbertogetoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_NUMBERTOGET);
+            rulemincostoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MINCOST);
+            rulemaxcostoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MAXCOST);
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            aisleshoprefoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_SHOP);
+            storenameoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            storecityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            storestreetoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST);
+        }
         TextView rulename = (TextView) view.findViewById(R.id.rulelistentry_rulename);
         TextView ruledate = (TextView) view.findViewById(R.id.rulelistentry_ruledate);
         CheckedTextView ruleprompt = (CheckedTextView) view.findViewById(R.id.rulelistentry_ruleprompttoadd);
         TextView ruleperiod = (TextView) view.findViewById(R.id.rulelistentry_ruleperiod);
 
-        rulename.setText(cursor.getString(1));
-        ruledate.setText(sdf.format(cursor.getLong(6)));
-        String freq = "Get <b><font color=\"BLACK\">" + cursor.getInt(10) + "</font></b> <b><font color=\"BLUE\">" + cursor.getString(13) + "</font></b> every ";
+        rulename.setText(cursor.getString(rulenameoffset));
+        ruledate.setText(sdf.format(cursor.getLong(ruleactiveonoffset)));
+        String freq = "Get <b><font color=\"BLACK\">" + cursor.getInt(rulenumbertogetoffset) + "</font></b> <b><font color=\"BLUE\">" + cursor.getString(productnameoffset) + "</font></b> every ";
         String periodasstr = "";
-        String loc = " from Aisle <b><font color=\"BLUE\">" + cursor.getString(14) + "</font></b> at <b><font color=\"BLUE\">" + cursor.getString(16) +
-                "</font></b> <font color=\"#4169E1\"><i>(" + cursor.getString(17) + " - " + cursor.getString(18) + ")</i></font>";
-        int promptstate = cursor.getInt(3);
+        String loc = " from Aisle <b><font color=\"BLUE\">" + cursor.getString(aislenameoffset) + "</font></b> at <b><font color=\"BLUE\">" + cursor.getString(storenameoffset) +
+                "</font></b> <font color=\"#4169E1\"><i>(" + cursor.getString(storestreetoffset) + " - " + cursor.getString(storecityoffset) + ")</i></font>";
+        int promptstate = cursor.getInt(rulepromptflagoffset);
         if (promptstate < 1) {
             ruleprompt.setChecked(true);
         } else {
             ruleprompt.setChecked(false);
         }
-        int period = cursor.getInt(4);
-        if (cursor.getInt(5) > 1) {
-            freq = freq + "<b><font color=\"BLACK\">" + cursor.getInt(5) + "</font></b> ";
-            switch (cursor.getInt(4)) {
+        int period = cursor.getInt(ruleperiodoffset);
+        if (cursor.getInt(rulemultiplieroffset) > 1) {
+            freq = freq + "<b><font color=\"BLACK\">" + cursor.getInt(rulemultiplieroffset) + "</font></b> ";
+            switch (cursor.getInt(ruleperiodoffset)) {
                 case Constants.PERIOD_DAYSASINT:
                     periodasstr = Constants.PERIOD_DAYS;
                     break;
@@ -83,7 +126,7 @@ public class RuleListAdapter extends CursorAdapter {
                     periodasstr = "UNKNOWN!!!";
             }
         } else {
-            switch (cursor.getInt(4)) {
+            switch (cursor.getInt(ruleperiodoffset)) {
                 case Constants.PERIOD_DAYSASINT:
                     periodasstr = Constants.PERIOD_DAYS_SINGULAR;
                     break;

--- a/app/src/main/java/mjt/shopper/ShopListSpinnerAdapter.java
+++ b/app/src/main/java/mjt/shopper/ShopListSpinnerAdapter.java
@@ -12,6 +12,14 @@ import android.widget.TextView;
  * Created by Mike092015 on 5/02/2016.
  */
 public class ShopListSpinnerAdapter extends CursorAdapter{
+    public static int storeidfoffset;
+    public static int storenameoffset;
+    public static int storeorderoffset;
+    public static int storestreetofffset;
+    public static int storecityoffset;
+    public static int storestateoffset;
+    public static int storephoneoffset;
+    public static int storenotesoffset;
 
     public ShopListSpinnerAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, FLAG_REGISTER_CONTENT_OBSERVER);
@@ -23,12 +31,22 @@ public class ShopListSpinnerAdapter extends CursorAdapter{
     }
     @Override
     public void bindView(View view,Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0 ) {
+            storeidfoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ID);
+            storenameoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            storeorderoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ORDER);
+            storestreetofffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+            storecityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            storestateoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STATE);
+            storephoneoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_PHONE);
+            storenotesoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NOTES);
+        }
         TextView textViewShopName = (TextView) view.findViewById(R.id.aasletv01);
         TextView textViewShopStreet = (TextView) view.findViewById(R.id.aasletv03);
         TextView textViewShopCity = (TextView) view.findViewById(R.id.aasletv02);
 
-        textViewShopName.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_NAME_INDEX));
-        textViewShopStreet.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_STREET_INDEX));
-        textViewShopCity.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_CITY_INDEX));
+        textViewShopName.setText(cursor.getString(storenameoffset));
+        textViewShopStreet.setText(cursor.getString(storestreetofffset));
+        textViewShopCity.setText(cursor.getString(storecityoffset));
     }
 }

--- a/app/src/main/java/mjt/shopper/ShopperDBHelper.java
+++ b/app/src/main/java/mjt/shopper/ShopperDBHelper.java
@@ -1028,6 +1028,7 @@ public class ShopperDBHelper extends SQLiteOpenHelper {
     public static final int    VALUES_COLUMN_VALUESETTINGSINFO_INDEX = 7;
     public static final String VALUES_COLUMN_VALUESETTINGSINFO_TYPE = "TEXT";
 
+
     public ShopperDBHelper(Context ctxt, String name, SQLiteDatabase.CursorFactory factory, int version) {
         super(ctxt, DATABASE_NAME, factory, 1); }
 
@@ -1612,9 +1613,9 @@ public class ShopperDBHelper extends SQLiteOpenHelper {
         String sqlstr = "SELECT " + PRODUCTUSAGE_COLUMN_AISLEREF + " AS _id, " +
             PRODUCTUSAGE_COLUMN_PRODUCTREF + ", " +
             PRODUCTUSAGE_COLUMN_COST + ", " +
-            PRODUCTS_TABLE_NAME + "." + PRODUCTS_COLUMN_ID + " AS products_id, " +
+            PRODUCTS_TABLE_NAME + "." + PRODUCTS_COLUMN_ID + " AS " + PRODUCTS_TABLE_NAME + PRODUCTS_COLUMN_ID + ", " +
             PRODUCTS_COLUMN_NAME + ", " +
-            AISLES_TABLE_NAME + "." + AISLES_COLUMN_ID + " AS aisles_id, " +
+            AISLES_TABLE_NAME + "." + AISLES_COLUMN_ID + " AS "+ AISLES_TABLE_NAME+AISLES_COLUMN_ID + ", " +
             AISLES_COLUMN_NAME + ", " +
             SHOPS_COLUMN_NAME + ", " +
             SHOPS_COLUMN_CITY + ", " +

--- a/app/src/main/java/mjt/shopper/ShopperDBHelper.java
+++ b/app/src/main/java/mjt/shopper/ShopperDBHelper.java
@@ -1,5 +1,6 @@
 package mjt.shopper;
 
+import android.app.Application;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -8,6 +9,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.util.Log;
 
+import java.io.File;
 import java.util.*;
 
 /**
@@ -192,6 +194,86 @@ class DBDatabase {
             //generatedSQLStatements.add(dbt.getSQLCreateString(db));
         }
         return generatedSQLStatements;
+    }
+    // Generate SQL that could be used to Build Database and Tables elsewhere (part 1 of export)
+    public String generateExportSchemaSQL() {
+        String sql = "";
+        String tablesql = "";
+        if(this.usable) {
+            sql = " CREATE DATABASE IF NOT EXISTS `" + this.database_name + "` ;\n" +
+                    " USE `" + this.database_name + "`;" ;
+            for(DBTable dbt : this.database_tables) {
+                tablesql = dbt.getSQLTableCreateAsString(true);
+                if(tablesql.length() > 0) {
+                    sql = sql + "\n " + tablesql;
+                }
+            }
+        }
+        return sql;
+    }
+    // Export All Table Data (not expect to work as no escaping as yet)
+    //TODO Getting close 1 issues.
+    //TODO 1 Need to do equiv to MYSQL_REAL_ESCAPE otherwise OK load
+    public String generateExportDataSQL(SQLiteDatabase db) {
+        String sql = "";
+        Cursor csr;
+        String coldata = "";
+        if(!this.usable) { return sql; }
+        sql = " USE `" + this.database_name + "`;\n";
+        for(DBTable dbt : this.database_tables) {
+            String sqlstr = " SELECT * FROM " + dbt.getDBTableName() + ";";
+            csr = db.rawQuery(sqlstr,null);
+            if(csr.getCount() > 0 ){
+                sql = sql + " INSERT INTO `" + dbt.getDBTableName() + "` (";
+                int coli = 0;
+                ArrayList<Integer> coltype = new ArrayList();
+                for(DBColumn dbtc : dbt.getTableDBColumns()) {
+                    if(coli++ > 0) {
+                        sql = sql + ", ";
+                    }
+                    if(dbtc.getDBColumnType().equals("TEXT")) {
+                        coltype.add(1);
+                    } else {
+                        coltype.add(0);
+                    }
+                    sql = sql + "`" + dbtc.getDBColumnName() + "` ";
+                }
+                sql = sql + ") VALUES \n ";
+                csr.moveToPosition(-1);
+                while(csr.moveToNext()) {
+                    sql = sql + "( ";
+                    for(int i=0; i < coli;i++) {
+                        coldata = csr.getString(i);
+                        if(coldata == null) {coldata = ""; }
+                        if(coltype.get(i) == 1) {
+                            if(coldata.length() > 0) {
+                                try {
+                                    coldata = coldata.replaceAll("\'", "#@APOST@#")
+                                            .replaceAll("\"", "#@QUOTE@#");
+                                } catch (Exception e) {
+                                    e.printStackTrace();
+                                }
+                            }
+                            sql = sql + "'" + coldata + "'";
+                        } else {
+                            sql = sql + csr.getString(i);
+                        }
+                        if(i < (coltype.size()-1)) {
+                            sql = sql + ", ";
+                        }
+                    }
+                    sql = sql + " )";
+                    if(csr.getPosition() < (csr.getCount() - 1) ) {
+                        sql = sql + ", \n";
+                    } else {
+                        sql = sql + "; \n";
+                    }
+                }
+            } else {
+                sql = sql + "-- ERROR - TABLE " + dbt.getDBTableName() + " IS EMPTY SKIPPED \n";
+            }
+        }
+        return sql;
     }
     //==============================================================================================
     // Actually perform the Table create statments (note CREATE IF NOT EXISTS) so will
@@ -435,6 +517,59 @@ class DBTable {
         // Main Loop through the columns
         for(DBColumn dc : this.table_columns) {
             part1 = part1 + dc.getDBColumnName() + " " + dc.getDBColumnType() + " ";
+            // Apply the default value if required
+            if(dc.getDBColumnDefaultValue().length() > 0 ) {
+                part1 = part1 + " DEFAULT " + dc.getDBColumnDefaultValue() + " ";
+            }
+            // if only 1 PRIMARY INDEX and this is it then add it
+            if(dc.getDBColumnIsPrimaryIndex() & indexes.size() == 1) {
+                part1 = part1 + " PRIMARY KEY ";
+            }
+            // If more to do then include comma separator
+            dccount++;
+            if (dccount < this.table_columns.size()) {
+                part1 = part1 + ", ";
+            }
+        }
+        // Handle multiple PRIMARY INDEXES ie add PRIMARY KEY (<col>, <col> .....)
+        int ixcount = 1;
+        if(indexes.size() > 1 ) {
+            part1 = part1 + ", PRIMARY KEY (";
+            for(String ix : indexes) {
+                part1 = part1 + ix;
+                if(ixcount < (indexes.size() ) ) {
+                    part1 = part1 + ", ";
+                }
+                ixcount++;
+            }
+            part1 = part1 + ")";
+        }
+        part1 = part1 + ") ;";
+        return part1;
+    }
+    //==============================================================================================
+    public String getSQLTableCreateAsString(Boolean doasmysql) {
+
+        // Extract Columns that are flagged as PRIMARY INDEXES so we have a count
+        // More than one has to be handled differently
+        ArrayList<String> indexes = new ArrayList<String>();
+        for(DBColumn dc : this.table_columns) {
+            if(dc.getDBColumnIsPrimaryIndex()) {
+                indexes.add(dc.getDBColumnName());
+            }
+        }
+        // Build the CREATE SQL
+        String part1 = " CREATE  TABLE IF NOT EXISTS `" + this.table_name + "` (";
+        int dccount = 0;
+        // Main Loop through the columns
+        for(DBColumn dc : this.table_columns) {
+            // FOR mysql export need to use BIGINT(20) instead of INTEGER
+            if(doasmysql && dc.getDBColumnType().equals("INTEGER")) {
+                part1 = part1 + "`" + dc.getDBColumnName() + "` BIGINT(20) NOT NULL ";
+            } else {
+                part1 = part1 + "`" + dc.getDBColumnName() + "` " + dc.getDBColumnType() + " ";
+            }
+
             // Apply the default value if required
             if(dc.getDBColumnDefaultValue().length() > 0 ) {
                 part1 = part1 + " DEFAULT " + dc.getDBColumnDefaultValue() + " ";
@@ -1083,6 +1218,18 @@ public class ShopperDBHelper extends SQLiteOpenHelper {
                     "- This is a Development Issue. Please contact the Developer.");
             return;
         }
+        //NOTE! Following lines can be used to export data in a fashion
+        // that is uncomment 5 lines of code put breakpoint on last String testx = ""
+        // and run in debug mode then copy value of exportschemasql to create database elsewhere
+        // e.g. phpmyadmin (paste in SQL at db level)
+        // do same for exportdatasql  to copy data.
+        // Note! not 100% e.g. apostrophes converted to #@APOST@# double quotes converted to #@QUOTE@#
+        //Following allows DB structure to be exported
+        //String exportschemasql = shopper.generateExportSchemaSQL();
+        //String exportdatasql = shopper.generateExportDataSQL(db);
+        //String test = exportschemasql;
+        //String test2 = exportdatasql;
+        //String testx = "";
 
         // Create a set of the SQL statments that would build ALL tables but due to IF NOT EXISTS
         // would only add new tables.

--- a/app/src/main/java/mjt/shopper/ShoppingListAdapter.java
+++ b/app/src/main/java/mjt/shopper/ShoppingListAdapter.java
@@ -18,6 +18,41 @@ import java.text.NumberFormat;
  * Created by Mike092015 on 21/03/2016.
  */
 public class ShoppingListAdapter extends CursorAdapter {
+    public static int shoplistidoffset;
+    public static int shoplistproductrefoffset;
+    public static int shoplistdateaddedoffset;
+    public static int shoplistnumbertogetoffset;
+    public static int shoplistdoneoffset;
+    public static int shoplistdategotoffset;
+    public static int shoplistcostoffset;
+    public static int shoplistproductusagerefoffset;
+    public static int shoplistaislerefoffset;
+    public static int productusageproductrefoffset; // NOTE SQL uses AS productusageid
+    public static int productusageaislerefoffset;
+    public static int productusagecostoffset;
+    public static int productusagebuycountoffset;
+    public static int productusagefirstbuydateoffset;
+    public static int productusagelatestbuydateoffset;
+    public static int productusagemincostoffset;
+    public static int productusageorderoffset;
+    public static int aisleidoffset; // NOTE SQL uses AS aisleid
+    public static int aislenameoffset;
+    public static int aisleorderoffset;
+    public static int aisleshopoffset;
+    public static int shopsidoffset; // NOTE SQL uses  AS shopid
+    public static int shopnameoffset;
+    public static int shoporderoffset;
+    public static int shopstreetoffset;
+    public static int shopcityoffset;
+    public static int shopstateoffset;
+    public static int shopphoneoffset;
+    public static int shopnotesoffset;
+    public static int productidoffset; // NOTE SQL uses AS productid
+    public static int productnameoffset;
+    public static int productorderoffset;
+    public static int productaisleoffset;
+    public static int productusesoffset;
+    public static int productnotesoffset;
 
     public ShoppingListAdapter(Context context, Cursor cursor, int flags, int myvar) {
         super(context, cursor, FLAG_REGISTER_CONTENT_OBSERVER);
@@ -62,6 +97,45 @@ public class ShoppingListAdapter extends CursorAdapter {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         int pos = cursor.getPosition();
 
+        if(pos == 0) {
+            shoplistidoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_ID);
+            shoplistproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_PRODUCTREF);
+            shoplistdateaddedoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_DATEADDED);
+            shoplistnumbertogetoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_NUMBERTOGET);
+            shoplistdoneoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_DONE);
+            shoplistdategotoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_DATEGOT);
+            shoplistcostoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_COST);
+            shoplistproductusagerefoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_PRODUCTUSAGEREF);
+            shoplistaislerefoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPLIST_COLUMN_AISLEREF);
+            productusageproductrefoffset = cursor.getColumnIndex("productusageid");
+            productusageaislerefoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_AISLEREF);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_AISLEREF);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST);
+            productusagebuycountoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_BUYCOUNT);
+            productusagefirstbuydateoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_FIRSTBUYDATE);
+            productusagelatestbuydateoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_LATESTBUYDATE);
+            productusagemincostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_MINCOST);
+            productusageorderoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_ORDER);
+            aisleidoffset = cursor.getColumnIndex("aisleid");
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            aisleorderoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_ORDER);
+            aisleshopoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_SHOP);
+            shopsidoffset = cursor.getColumnIndex("shopid");
+            shopnameoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            shoporderoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ORDER);
+            shopstreetoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+            shopcityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            shopstateoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STATE);
+            shopphoneoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_PHONE);
+            shopnotesoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NOTES);
+            productidoffset = cursor.getColumnIndex("productid");
+            productnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            productorderoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_ORDER);
+            productaisleoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_AISLE);
+            productusesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_USES);
+            productnotesoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NOTES);
+        }
+
         LinearLayout shophdrll = (LinearLayout) view.findViewById(R.id.shoppinglist_shopheader);
         LinearLayout aislehdrll = (LinearLayout) view.findViewById(R.id.shoppinglist_aisleheader);
 
@@ -91,36 +165,36 @@ public class ShoppingListAdapter extends CursorAdapter {
         // and prevaisle to 0 (no such id's) will force this (as won't be changed)
         if(pos > 0 ) {
             cursor.moveToPrevious();
-            prevshop = cursor.getLong(21); //  shopid column
-            prevaisle = cursor.getLong(17); // aisleid column
+            prevshop = cursor.getLong(shopsidoffset); //  shopid column
+            prevaisle = cursor.getLong(aisleidoffset); // aisleid column
             cursor.moveToNext(); // Restore cursor position to current
         }
-        if(prevshop != cursor.getLong(21)) {
+        if(prevshop != cursor.getLong(shopsidoffset)) {
             shophdrll.setVisibility(View.VISIBLE);
             shophdrll.setBackgroundColor(ContextCompat.getColor(context, R.color.colorlistviewheading));
         } else {
             shophdrll.setVisibility(View.GONE);
         }
-        if(prevaisle != cursor.getLong(17)) {
+        if(prevaisle != cursor.getLong(aisleidoffset)) {
             aislehdrll.setVisibility(View.VISIBLE);
             aislehdrll.setBackgroundColor(ContextCompat.getColor(context, R.color.colorlistviewsubheading));
         } else {
             aislehdrll.setVisibility(View.GONE);
         }
-        shopnametv.setText(cursor.getString(22));
-        shopcitytv.setText(cursor.getString(25));
-        shopstreettv.setText(cursor.getString(24));
-        aislenametv.setText(cursor.getString(18));
-        productnametv.setText(cursor.getString(30));
-        quantitytv.setText(cursor.getString(3));
-        pricetv.setText(NumberFormat.getCurrencyInstance().format(cursor.getDouble(11)));
-        priceforalltv.setText(NumberFormat.getCurrencyInstance().format(cursor.getDouble(3) * cursor.getDouble(11)));
-        shopordertv.setText(cursor.getString(23));
-        shopidtv.setText(cursor.getString(21));
-        aisleordertv.setText(cursor.getString(19));
-        aisleidtv.setText(cursor.getString(17));
-        puordertv.setText(cursor.getString(16));
-        puprodreftv.setText(cursor.getString(9));
+        shopnametv.setText(cursor.getString(shopnameoffset));
+        shopcitytv.setText(cursor.getString(shopcityoffset));
+        shopstreettv.setText(cursor.getString(shopstreetoffset));
+        aislenametv.setText(cursor.getString(aislenameoffset));
+        productnametv.setText(cursor.getString(productnameoffset));
+        quantitytv.setText(cursor.getString(shoplistnumbertogetoffset));
+        pricetv.setText(NumberFormat.getCurrencyInstance().format(cursor.getDouble(productusagecostoffset)));
+        priceforalltv.setText(NumberFormat.getCurrencyInstance().format(cursor.getDouble(shoplistnumbertogetoffset) * cursor.getDouble(productusagecostoffset)));
+        shopordertv.setText(cursor.getString(shoporderoffset));
+        shopidtv.setText(cursor.getString(shopsidoffset));
+        aisleordertv.setText(cursor.getString(aisleorderoffset));
+        aisleidtv.setText(cursor.getString(aisleidoffset));
+        puordertv.setText(cursor.getString(productusageorderoffset));
+        puprodreftv.setText(cursor.getString(productusageproductrefoffset));
         // Set tags to enable onClick to determine the cursor position of the clicked entry
         donebtntv.setTag(pos);
         deletebtntv.setTag(pos);

--- a/app/src/main/java/mjt/shopper/ShoppingListPromptedRulesAdapter.java
+++ b/app/src/main/java/mjt/shopper/ShoppingListPromptedRulesAdapter.java
@@ -17,6 +17,26 @@ import java.text.SimpleDateFormat;
  * Created by Mike092015 on 29/04/2016.
  */
 public class ShoppingListPromptedRulesAdapter extends CursorAdapter {
+    public static int ruleidoffset;
+    public static int rulenameoffset;
+    public static int ruletypeoffset;
+    public static int rulepromptflagoffset;
+    public static int ruleperiodoffset;
+    public static int rulemultipleroffset;
+    public static int ruleactiveonoffset;
+    public static int ruleproductrefoffset;
+    public static int ruleaislerefoffset;
+    public static int ruleusesoffset;
+    public static int rulenumbertogetoffset;
+    public static int rulemincostoffset;
+    public static int rulemaxcostoffset;
+    public static int productsnameoffset;
+    public static int aislenameoffset;
+    public static int aisleshopoffset;
+    public static int shopnameoffset;
+    public static int shopcityoffset;
+    public static int shopstreetoffset;
+    public static int productusagecostoffset;
 
     public SimpleDateFormat sdf = new SimpleDateFormat(Constants.EXTENDED__DATE_DORMAT);
 
@@ -42,11 +62,33 @@ public class ShoppingListPromptedRulesAdapter extends CursorAdapter {
     }
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
+        if(cursor.getPosition() == 0) {
+            ruleidoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_ID);
+            rulenameoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_NAME);
+            ruletypeoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_TYPE);
+            rulepromptflagoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PROMPTFLAG);
+            ruleperiodoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PERIOD);
+            rulemultipleroffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MULTIPLIER);
+            ruleactiveonoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_ACTIVEON);
+            ruleproductrefoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_PRODUCTREF);
+            ruleaislerefoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_AISLEREF);
+            ruleusesoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_USES);
+            rulenumbertogetoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_NUMBERTOGET);
+            rulemincostoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MINCOST);
+            rulemaxcostoffset = cursor.getColumnIndex(ShopperDBHelper.RULES_COLUMN_MAXCOST);
+            productsnameoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTS_COLUMN_NAME);
+            aislenameoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_NAME);
+            aisleshopoffset = cursor.getColumnIndex(ShopperDBHelper.AISLES_COLUMN_SHOP);
+            shopnameoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            shopcityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            shopstreetoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+            productusagecostoffset = cursor.getColumnIndex(ShopperDBHelper.PRODUCTUSAGE_COLUMN_COST);
+        }
 
 
         String periodstr;
-        if(cursor.getInt(5) > 1) {
-            switch(cursor.getInt(4)) {
+        if(cursor.getInt(rulemultipleroffset) > 1) {
+            switch(cursor.getInt(ruleperiodoffset)) {
                 case Constants.PERIOD_DAYSASINT:
                     periodstr = Constants.PERIOD_DAYS;
                     break;
@@ -69,7 +111,7 @@ public class ShoppingListPromptedRulesAdapter extends CursorAdapter {
                     periodstr = "UNKNOWN!!!";
             }
         } else {
-            switch(cursor.getInt(4)) {
+            switch(cursor.getInt(ruleperiodoffset)) {
                 case Constants.PERIOD_DAYSASINT:
                     periodstr = Constants.PERIOD_DAYS_SINGULAR;
                     break;
@@ -98,16 +140,16 @@ public class ShoppingListPromptedRulesAdapter extends CursorAdapter {
         TextView ruledate = (TextView) view.findViewById(R.id.autoaddprompt_ruledate);
         TextView ruleastext = (TextView) view.findViewById(R.id.autoprompt_ruleastext);
 
-        String ruleastextstr = "Get <font color=\"BLACK\">" + cursor.getString(10) + " </font>" +
-                "<font color=\"BLUE\">" + cursor.getString(13) + "</font>" +
-                " every <font color=\"BLACK\">" + cursor.getString(5) + " </font>" +
+        String ruleastextstr = "Get <font color=\"BLACK\">" + cursor.getString(rulenumbertogetoffset) + " </font>" +
+                "<font color=\"BLUE\">" + cursor.getString(productsnameoffset) + "</font>" +
+                " every <font color=\"BLACK\">" + cursor.getString(rulemultipleroffset) + " </font>" +
                 "<font color=\"BLUE\">" + periodstr + "</font>" +
-                " from Ailse " + "<font color=\"BLUE\">" + cursor.getString(14) + "</font>" +
-                " at " + "<font color=\"BLUE\">" + cursor.getString(16) + "</font>" +
-                " <font color=\"#4169E1\"><i>(" + cursor.getString(17) +
-                " - " + cursor.getString(18) + ")</i></font>";
-        rulename.setText(cursor.getString(1));
-        ruledate.setText(sdf.format(cursor.getLong(6)));
+                " from Ailse " + "<font color=\"BLUE\">" + cursor.getString(aislenameoffset) + "</font>" +
+                " at " + "<font color=\"BLUE\">" + cursor.getString(shopnameoffset) + "</font>" +
+                " <font color=\"#4169E1\"><i>(" + cursor.getString(shopcityoffset) +
+                " - " + cursor.getString(shopstreetoffset) + ")</i></font>";
+        rulename.setText(cursor.getString(rulenameoffset));
+        ruledate.setText(sdf.format(cursor.getLong(ruleactiveonoffset)));
         ruleastext.setText(Html.fromHtml(ruleastextstr));
     }
     @Override

--- a/app/src/main/java/mjt/shopper/ShopsCursorAdapter.java
+++ b/app/src/main/java/mjt/shopper/ShopsCursorAdapter.java
@@ -13,6 +13,15 @@ import android.widget.TextView;
  * Created by Mike092015 on 2/02/2016.
  */
 class ShopsCursorAdapter extends CursorAdapter {
+    public static int storeidfoffset;
+    public static int storenameoffset;
+    public static int storeorderoffset;
+    public static int storestreetofffset;
+    public static int storecityoffset;
+    public static int storestateoffset;
+    public static int storephoneoffset;
+    public static int storenotesoffset;
+
     public ShopsCursorAdapter(Context context, Cursor cursor, int flags) {
         super(context, cursor, 0);
     }
@@ -34,6 +43,17 @@ class ShopsCursorAdapter extends CursorAdapter {
     }
     @Override
     public void bindView(View view,Context context, Cursor cursor) {
+        // get column offsets from cursor (once to reduce overheads)
+        if(cursor.getPosition() == 0 ) {
+            storeidfoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ID);
+            storenameoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NAME);
+            storeorderoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_ORDER);
+            storestreetofffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STREET);
+            storecityoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_CITY);
+            storestateoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_STATE);
+            storephoneoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_PHONE);
+            storenotesoffset = cursor.getColumnIndex(ShopperDBHelper.SHOPS_COLUMN_NOTES);
+        }
         //TextView textviewShopid = (TextView) view.findViewById(R.id.shop_id_entry);
         TextView textViewShopName = (TextView) view.findViewById(R.id.shop_name_entry);
         TextView textViewShopOrder = (TextView) view.findViewById(R.id.shop_order_entry);
@@ -44,12 +64,12 @@ class ShopsCursorAdapter extends CursorAdapter {
         TextView textViewShopNotes = (TextView) view.findViewById(R.id.shop_notes_entry);
 
         //textviewShopid.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMNN_ID_INDEX));
-        textViewShopName.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_NAME_INDEX));
-        textViewShopOrder.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_ORDER_INDEX));
-        textViewShopStreet.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_STREET_INDEX));
-        textViewShopCity.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_CITY_INDEX));
-        textViewShopState.setText(cursor.getString(ShopperDBHelper.SHOPS_COLUMN_STATE_INDEX));
-        textViewShopPhone.setText(cursor.getString(ShopperDBHelper.SHOPS_COULMN_PHONE_INDEX));
-        textViewShopNotes.setText(cursor.getString(ShopperDBHelper.SHOPS_COULMN_NOTES_INDEX));
+        textViewShopName.setText(cursor.getString(storenameoffset));
+        textViewShopOrder.setText(cursor.getString(storeorderoffset));
+        textViewShopStreet.setText(cursor.getString(storestreetofffset));
+        textViewShopCity.setText(cursor.getString(storecityoffset));
+        textViewShopState.setText(cursor.getString(storestateoffset));
+        textViewShopPhone.setText(cursor.getString(storephoneoffset));
+        textViewShopNotes.setText(cursor.getString(storenotesoffset));
     }
 }


### PR DESCRIPTION
Change all ListView/Spinner adapters to retrieve cursor offsets via column names as opposed to using hard coded offsets. Thus should reduce maintenance overheads and facilitate table modifications that would have meant that offsets had to be re-visited.

Still minor issue with some that don't use defined column names via SQL AS. These should only be _id fields where joins are used or when link tables (associative tables) are used as they do not have column _id and thus AS is used to create column _id (e.g. productusage table).
