### PR TITLE
User guide stuff

### DIFF
--- a/app/src/main/java/mjt/shopper/MainActivity.java
+++ b/app/src/main/java/mjt/shopper/MainActivity.java
@@ -27,11 +27,7 @@ import java.util.Date;
 // Setup Values table (if already done then duplicates won't be added)
 // Button handling as per xml then handle selection of options
 
-//TODO update manual for new features added
-//TODO additional settings for Rule Selection 3; allow suggestions, freq and Next suggest
-//TODO update manual for addition actions (...) Data handling and Rule suggestions
-//TODO update manual to fully cover Datahandling
-//TODO update manual to full cover Rule Suggestion
+//TODO Allow Enabling of Disabled Rule Suggestions
 //TODO Help display for Rule Suggestion
 
 public class MainActivity extends AppCompatActivity {
@@ -233,9 +229,28 @@ public class MainActivity extends AppCompatActivity {
         mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
                 THIS_ACTIVITY,"getSettings",developermode);
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        developermode = sharedPreferences.getBoolean(getString(R.string.sharedpreferencekey_developermode),false);
-        helpoffmode = sharedPreferences.getBoolean(getString(R.string.sharedpreferencekey_showhelpmode),false);
-        rulesuggestion = sharedPreferences.getBoolean(getString(R.string.sharedpreferencekey_allowrulesuggest),true);
+        //Developer Mode - Allows Data and Schema buttons does additional log writing
+        developermode = sharedPreferences.getBoolean(
+                getString(
+                        R.string.sharedpreferencekey_developermode
+                ),
+                false
+        );
+        // HelpOffMode - DIsable/Enable help displays
+        helpoffmode = sharedPreferences.getBoolean(
+                getString(
+                        R.string.sharedpreferencekey_showhelpmode
+                ),
+                false
+        );
+        // Diable/Enable Regular Rule suggestions
+        rulesuggestion = sharedPreferences.getBoolean(
+                getString(
+                        R.string.sharedpreferencekey_allowrulesuggest
+                ),
+                true
+        );
+        // Number of days between rule suggestions
         rulesuggestionfrequency =
                 Integer.parseInt(
                         sharedPreferences.getString(getResources().getString(
@@ -245,13 +260,16 @@ public class MainActivity extends AppCompatActivity {
                 );
     }
 
-    //==============================================================================================
-    // Select Buttons that are to be dissplayed
-    // Displays buttons relevant to the current state/context i.e. DB state and developermode
-    // e.g. if no stores or products then only Stores and Products buttons as other information is
-    // dependany up stores or products (and so on as per comments)
-    // developer mode is independant of stores/products etc if true then display DATA and SCHEMA
-    // buttons else display neither.
+    /**
+     * Method - selectButtons - Turn buttons on/off according to various states
+     * Stores Button is always available.
+     * The Aisles button will only be available if at least 1 store exists
+     * Products Button is always available.
+     * To Get Button is only available when at least one product is assigned
+     *      to an aisle. As such at least one aisle and one product exists and
+     *      therefore that at least one shop exists.
+     *
+     */
     private void selectButtons() {
         mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
                 THIS_ACTIVITY,"selectButtons",developermode);
@@ -304,8 +322,7 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-        // Only show ShoppingList button if there are shops and there are products and there are
-        // products in aisles.
+        // Only show ShoppingList button if at least one shopping list row wxists
         if(shoppinglistcount < 1 & rulecount < 1) {
             shoppinglistbutton.setVisibility(View.GONE);
             shoppinglisthelpbutton.setVisibility(View.GONE);
@@ -339,9 +356,11 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    //==============================================================================================
-    // Get statistics # of shops, aisles, products, products in aisles, rules and shopping list entries.
-    // Also show date and time and then timestamp. Only shown in developer mode.
+    /**
+     * Set database row count display views
+     * Also Date and Timestamps
+     * Note! Data is only displayed when developer Mode is on.
+     */
     private void handleStats() {
         mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
                 THIS_ACTIVITY,"handleStats",developermode);
@@ -372,10 +391,17 @@ public class MainActivity extends AppCompatActivity {
         stats.setText(statstr);
     }
 
-    //==============================================================================================
-    // Do Initialisation checks -
-    // expand database (add any new tables and/or columns)
-    // if no stores(shops) then invoke store add
+    /**
+     * Method - initialisationChecks - invoke the onExpand method
+     * The onExpand method checks the actual database against a
+     *      proposed structure adding tables and columns if any
+     *      are missing.
+     * This is an alternative method to using the SQLIte onUpgrade.
+     * Classes ShopperDBHelper.DBColumn, DBTable and DBDatabase,
+     *      all in ShopperDBHelper.java, have additional information
+     * Note! invoking the ShopAddActivity if no stores exists has
+     *      been commented out as it may be confusing.
+     */
     private void initialisationChecks() {
         mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
                 THIS_ACTIVITY,"initialisationChecks",developermode);
@@ -383,11 +409,13 @@ public class MainActivity extends AppCompatActivity {
         ShopperDBHelper shopperdb = new ShopperDBHelper(this,null,null,1);
         shopperdb.onExpand();
 
+        /*
         if(shopcount < 1 ) {
             Intent intent = new Intent(this, ShopAddActivity.class);
             intent.putExtra("Caller",THIS_ACTIVITY);
             startActivity(intent);
         }
+        */
         shopperdb.close();
     }
 
@@ -468,7 +496,12 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    // Check if Database exists
+    /**
+     * method doesDatabaseExist - Checks if the database exists
+     * @param context
+     * @param dbName
+     * @return true if the database file exists, false if not
+     */
     public boolean doesDatabaseExist(Context context, String dbName) {
         mjtUtils.logMsg(mjtUtils.LOG_INFORMATIONMSG,"Method Call",
                 THIS_ACTIVITY,"doesDatabaseExist",developermode);

--- a/app/src/main/java/mjt/shopper/MainDataHandlingActivity.java
+++ b/app/src/main/java/mjt/shopper/MainDataHandlingActivity.java
@@ -13,6 +13,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -58,6 +59,7 @@ public class MainDataHandlingActivity extends AppCompatActivity {
     private Spinner dbrestore_spinner;
     private TextView dbbutton;
     private TextView dbfcnt;
+    private TextView dbrestorebutton;
 
     private EditText sqlbasefilename;
     private EditText sqlfileext;
@@ -65,6 +67,7 @@ public class MainDataHandlingActivity extends AppCompatActivity {
     private Spinner sqlrestore_spinner;
     private TextView sqlbutton;
     private TextView sqlfcnt;
+    private TextView sqlrestorebutton;
 
     private EditText dumpbasefilename;
     private EditText dumpfileext;
@@ -128,6 +131,7 @@ public class MainDataHandlingActivity extends AppCompatActivity {
         dbrestore_spinner = (Spinner) findViewById(R.id.dh_dbrestore_spinner);
         dbbutton = (TextView) findViewById(R.id.dh_dbsave);
         dbfcnt = (TextView) findViewById(R.id.dh_dbrestore_fcnt);
+        dbrestorebutton = (TextView) findViewById(R.id.dh_dbrestore);
 
         sqlbasefilename = (EditText) findViewById(R.id.dh_sqlsave_basefilename);
         sqlfileext = (EditText) findViewById(R.id.dh_sqlsave_fileext);
@@ -135,6 +139,7 @@ public class MainDataHandlingActivity extends AppCompatActivity {
         sqlrestore_spinner = (Spinner) findViewById(R.id.dh_sqlrestore_spinner);
         sqlbutton = (TextView) findViewById(R.id.dh_sqlsave);
         sqlfcnt = (TextView) findViewById(R.id.dh_sqlrestore_fcnt);
+        sqlrestorebutton = (TextView) findViewById(R.id.dh_sqlrestore);
 
         dumpbasefilename = (EditText) findViewById(R.id.dh_dumpsave_basefilename);
         dumpfileext = (EditText) findViewById(R.id.dh_dumpsave_fileext);
@@ -286,20 +291,25 @@ public class MainDataHandlingActivity extends AppCompatActivity {
                 dbfcnt,
                 dbbasefilename.getText().toString(),
                 dbfileext.getText().toString(),
-                sdbase
+                sdbase,
+                dbrestorebutton
         );
         //SQL
         populateRestoreSpinner(sqlrestore_spinner,
                 sqlfcnt,
                 sqlbasefilename.getText().toString(),
                 sqlfileext.getText().toString(),
-                sdbase);
+                sdbase,
+                sqlrestorebutton
+        );
         //DUMP
         populateRestoreSpinner(dumprestore_spinner,
                 dumpfcnt,
                 dumpbasefilename.getText().toString(),
                 dumpfileext.getText().toString(),
-                sdbase);
+                sdbase,
+                null
+        );
     }
 
     /**
@@ -310,7 +320,7 @@ public class MainDataHandlingActivity extends AppCompatActivity {
      * @param fileext - fileextension
      * @param sd - StoreData
      */
-    private void populateRestoreSpinner(Spinner spn, TextView tv, String basefilename, String fileext, StoreData sd) {
+    private void populateRestoreSpinner(Spinner spn, TextView tv, String basefilename, String fileext, StoreData sd, TextView restorebutton) {
 
         String spnname = "";
         boolean used = false;
@@ -348,9 +358,22 @@ public class MainDataHandlingActivity extends AppCompatActivity {
         }
 
         // Reverse the order of the list so most recent backups appear first
+        // Also hide/show the Restore button and spinner according to if
+        // files exist or not
+        // (doing nothing in the case where the is no restore button i.e.
+        //  null has been passed)
         if(flst.size() > 0) {
             for (int i = (flst.size() -1); i >= 0; i--) {
                 reverseflist.add(flst.get(i));
+            }
+            if (restorebutton != null) {
+                spn.setVisibility(View.VISIBLE);
+                restorebutton.setVisibility(View.VISIBLE);
+            }
+        } else {
+            if (restorebutton != null) {
+                spn.setVisibility(View.INVISIBLE);
+                restorebutton.setVisibility(View.INVISIBLE);
             }
         }
 
@@ -442,6 +465,22 @@ public class MainDataHandlingActivity extends AppCompatActivity {
         copydbfilename = currentdbfilename +
                 "OLD" +
                 getDateandTimeasYYMMDDhhmm();
+        if(dbrestore_spinner.getSelectedItemPosition() == AdapterView.INVALID_POSITION) {
+            AlertDialog.Builder notokdialog = new AlertDialog.Builder(this);
+            notokdialog.setTitle("No DB Restore File.");
+            notokdialog.setMessage("There is no file to restore from selected." +
+                    "\n\nThe restore request cannot be undertaken" +
+                    " and will be cancelled. "
+            );
+            notokdialog.setCancelable(true);
+            notokdialog.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialogInterface, int i) {
+
+                }
+            }).show();
+            return;
+        }
         backupfilename = dbrestore_spinner.getSelectedItem().toString();
 
         AlertDialog.Builder okdialog = new AlertDialog.Builder(this);
@@ -678,6 +717,22 @@ public class MainDataHandlingActivity extends AppCompatActivity {
     private void restoreSQL() {
         currentdbfilename = this.getDatabasePath(ShopperDBHelper.DATABASE_NAME).getPath();
         copydbfilename = currentdbfilename + "OLDSQL" + getDateandTimeasYYMMDDhhmm();
+        if(sqlrestore_spinner.getSelectedItemPosition() == AdapterView.INVALID_POSITION) {
+            AlertDialog.Builder notokdialog = new AlertDialog.Builder(this);
+            notokdialog.setTitle("No SQL Restore File.");
+            notokdialog.setMessage("There is no file to restore from selected." +
+                    "\n\nThe restore request cannot be undertaken," +
+                    " so the request will be cancelled."
+            );
+            notokdialog.setCancelable(true);
+            notokdialog.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialogInterface, int i) {
+
+                }
+            }).show();
+            return;
+        }
         backupfilename = sqlrestore_spinner.getSelectedItem().toString();
 
         AlertDialog.Builder okdialog = new AlertDialog.Builder(this);

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -118,7 +118,8 @@
             android:layout_width="700sp"
             android:layout_height="350sp"
             android:layout_centerHorizontal="true"
-            android:background="#EEEEEE"/>
+            android:background="#EEEEEE"
+            android:visibility="invisible"/>
         <TextView
             android:id="@+id/amtv10"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Restores could bomb out if no backup file for the restore option, resulting in empty spinner causing null exception when trying to convert value of selected item to a string. Changed spinner handling by checking selected position was valid. However, also added code to disable buttons and spinners when no files exist.